### PR TITLE
fix: recover from errors thrown or emitted by sharp stream

### DIFF
--- a/src/lib/imageopto-types.ts
+++ b/src/lib/imageopto-types.ts
@@ -27,7 +27,7 @@ export interface IRequestErrors {
  * Receives a {@link RequestErrors} object to do side effects such as logging.
  * Default prints to stderr.
  */
-export type ErrorLogger = (errors: IRequestErrors) => any;
+export type ErrorLogger = (errors: IRequestErrors | Error) => any;
 
 export type Param =
   | 'bg-color'

--- a/src/lib/map-options.ts
+++ b/src/lib/map-options.ts
@@ -9,7 +9,7 @@
 
 import accepts from 'accepts';
 import { Request } from 'express';
-import sharp from 'sharp';
+import { Sharp } from 'sharp';
 import { Format, IFastlyParams, Mapper, Param } from './imageopto-types';
 
 import bgFlatten from './mappers/background-flatten';
@@ -70,11 +70,11 @@ function supportsWebP(req: Request): boolean {
 /**
  * @hidden
  */
-export default function optoToSharp(params: IFastlyParams) {
+export default function optoToSharp(params: IFastlyParams, sharpStream: Sharp) {
   const applied = new Set();
   const { req, res, log } = params;
   const { query } = req;
-  let transform = sharp();
+  let transform = sharpStream;
   for (const [name, mapper] of mappers) {
     if (query.hasOwnProperty(name) && !applied.has(mapper)) {
       log.debug('running mapper for %s', name);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds exception handling and stream error handling to the code which creates a sharp stream.

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/magento/pwa-studio/issues/2448

Throws a big fat exception and maybe crashes the process when the sharp stream throws during mapping, or emits an error during processing.


* **What is the new behavior (if this is a feature change)?**

Catches both types of error and logs them as errors.

* **Other information**:
