### PR TITLE
fix: use originalUrl and adjust regex to match new format

### DIFF
--- a/src/lib/imageopto.ts
+++ b/src/lib/imageopto.ts
@@ -55,7 +55,7 @@ HASTILY_STREAMABLE_FILETYPES.add('jpg');
 // minus SVGs, which are widely supported in 2019 and we should not rasterize
 HASTILY_STREAMABLE_FILETYPES.delete('svg');
 export const HASTILY_STREAMABLE_PATH_REGEXP = new RegExp(
-  `\\.(?:${[...HASTILY_STREAMABLE_FILETYPES].join('|')})`
+  `/.+\\.(${[...HASTILY_STREAMABLE_FILETYPES].join('|')})(?:[?#].*)?`
 );
 
 /**
@@ -64,7 +64,7 @@ export const HASTILY_STREAMABLE_PATH_REGEXP = new RegExp(
  * @param req {Request}
  */
 export const hasSupportedExtension: RequestFilter = (req) =>
-  HASTILY_STREAMABLE_PATH_REGEXP.test(req.path);
+  HASTILY_STREAMABLE_PATH_REGEXP.test(req.originalUrl);
 
 /**
  * Returns a new imageopto middleware for use in Express `app.use()`.
@@ -89,7 +89,7 @@ export function imageopto(
   constructorLog.debug('creating new middleware');
   if (options.filter === hasSupportedExtension) {
     constructorLog.debug(
-      'middleware filtering req.path for %s',
+      'middleware filtering req.originalUrl for %s',
       HASTILY_STREAMABLE_PATH_REGEXP.source
     );
   }

--- a/src/lib/imageopto.ts
+++ b/src/lib/imageopto.ts
@@ -55,7 +55,7 @@ HASTILY_STREAMABLE_FILETYPES.add('jpg');
 // minus SVGs, which are widely supported in 2019 and we should not rasterize
 HASTILY_STREAMABLE_FILETYPES.delete('svg');
 export const HASTILY_STREAMABLE_PATH_REGEXP = new RegExp(
-  `\\.(?:${[...HASTILY_STREAMABLE_FILETYPES].join('|')})$`
+  `\\.(?:${[...HASTILY_STREAMABLE_FILETYPES].join('|')})`
 );
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Image paths with URL parameters don't pass this regex (eg. `image.jpg?auto=webp`)


* **What is the new behavior (if this is a feature change)?**
Optimizes image paths with url parameters


* **Other information**:
