### PR TITLE
fix(opts): filter now optional and matches whole url

### DIFF
--- a/src/lib/imageopto.ts
+++ b/src/lib/imageopto.ts
@@ -55,7 +55,7 @@ HASTILY_STREAMABLE_FILETYPES.add('jpg');
 // minus SVGs, which are widely supported in 2019 and we should not rasterize
 HASTILY_STREAMABLE_FILETYPES.delete('svg');
 export const HASTILY_STREAMABLE_PATH_REGEXP = new RegExp(
-  `\\.(?:${[...HASTILY_STREAMABLE_FILETYPES].join('|')})$`
+  `/.+\\.(${[...HASTILY_STREAMABLE_FILETYPES].join('|')})(?:[?#].*)?`
 );
 
 /**
@@ -64,7 +64,7 @@ export const HASTILY_STREAMABLE_PATH_REGEXP = new RegExp(
  * @param req {Request}
  */
 export const hasSupportedExtension: RequestFilter = (req) =>
-  HASTILY_STREAMABLE_PATH_REGEXP.test(req.path);
+  HASTILY_STREAMABLE_PATH_REGEXP.test(req.originalUrl);
 
 /**
  * Returns a new imageopto middleware for use in Express `app.use()`.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* HASTILY_STREAMABLE_PATH_REGEXP now matches the whole URL (making it compatible
  with Express middleware paths)
* hasSupportedExtension now tests against the Express `req.originalUrl` instead
  of `req.path`, so it can be used in early Express middlewares before the
  `req.path` is populated

Replaces and closes #22.